### PR TITLE
Support schedules starting at midnight

### DIFF
--- a/pyephember2/pyephember2.py
+++ b/pyephember2/pyephember2.py
@@ -211,6 +211,8 @@ def scheduletime_to_time(dict, key_name):
     stime = dict[key_name]
     if stime is None:
         return None
+    elif stime == 0:                                               
+        return datetime.time(0, 0)
     return datetime.time(int(str(stime)[:-1]), 10 * int(str(stime)[-1:]))
 
 def getZoneTime(zone):


### PR DESCRIPTION
I had been using a locally forked pyember library to work around some problems. When converting my homeassistant install to use the now fixed upstream ephember library, I ran into a crash with my heating schedule which started at midnight. 

```
{... 'startTime': 0, 'updateTime': None, 'Prev': {'createTime': None, 'delFlag': None, 'endTime': 235, ..., 'startTime': 235, ...
```

This 0 broke schedule_to_time, which the resulting patch corrects. 

Thanks for fixing this project for everyone! 