### PR TITLE
Fix ZoneCommand missing index argument

### DIFF
--- a/pyephember2/pyephember2.py
+++ b/pyephember2/pyephember2.py
@@ -767,7 +767,7 @@ class EphEmber:
     def _set_zone_boost_temperature(self, zone, target_temperature):
         return self.messenger.send_zone_commands(
             zone,
-            ZoneCommand('BOOST_TEMP', target_temperature)
+            ZoneCommand('BOOST_TEMP', target_temperature, None)
         )
 
     def _set_zone_advance(self, zone, advance=True):
@@ -777,7 +777,7 @@ class EphEmber:
             advance = 0
         return self.messenger.send_zone_commands(
             zone,
-            ZoneCommand('ADVANCE_ACTIVE', advance)
+            ZoneCommand('ADVANCE_ACTIVE', advance, None)
         )
 
     def _set_zone_boost(self, zone, boost_temperature, num_hours, timestamp=0):
@@ -793,13 +793,13 @@ class EphEmber:
         If timestamp is None, do not send timestamp at all.
         (maybe results in permanent boost?)
         """
-        cmds = [ZoneCommand('BOOST_HOURS', num_hours)]
+        cmds = [ZoneCommand('BOOST_HOURS', num_hours, None)]
         if boost_temperature is not None:
-            cmds.append(ZoneCommand('BOOST_TEMP', boost_temperature))
+            cmds.append(ZoneCommand('BOOST_TEMP', boost_temperature, None))
         if timestamp is not None:
             if timestamp == 0:
                 timestamp = int(datetime.datetime.now().timestamp())
-            cmds.append(ZoneCommand('BOOST_TIME', timestamp))
+            cmds.append(ZoneCommand('BOOST_TIME', timestamp, None))
         return self.messenger.send_zone_commands(zone, cmds)
 
     def _set_zone_mode(self, zone, mode_num, index):


### PR DESCRIPTION


The ZoneCommand namedtuple requires 3 arguments (name, value, index), but several methods were only passing 2 arguments, causing:
  TypeError: ZoneCommand.__new__() missing 1 required positional argument: 'index'

Fixed methods:
- _set_zone_boost_temperature
- _set_zone_advance
- _set_zone_boost

Pass None as the third argument (index) to allow zone_command_to_ints to fall back to GetPointIndex() for determining the correct index.

I came across this when I tried to modify the integration for homeassistant (see here: [https://github.com/UtzR/ephember](https://github.com/UtzR/ephember))


